### PR TITLE
Devquinteros/hab 23 createcontext for habitat model

### DIFF
--- a/src/components/Authentication/Auth/Auth.tsx
+++ b/src/components/Authentication/Auth/Auth.tsx
@@ -4,19 +4,20 @@
 import { Authenticator, Button, useAuthenticator } from '@aws-amplify/ui-react';
 import { Auth } from 'aws-amplify';
 import { usePostHog } from 'posthog-js/react';
-
-import { Habitat } from 'models';
-
+import useHabitat from 'hooks/utils/useHabitat';
 import styles from './styles.module.css';
 
 interface AuthProps {
   type: 'applicant' | 'affiliate';
-  header: string;
-  habitat: Habitat;
 }
 
-const AuthComponent = ({ habitat, type, header }: AuthProps) => {
+const AuthComponent = ({ type }: AuthProps) => {
+  const { habitat } = useHabitat();
+
+  const header = habitat?.authenticationHeader || '';
+
   const posthog = usePostHog();
+
   const auth = useAuthenticator();
 
   const formFields = {
@@ -126,7 +127,7 @@ const AuthComponent = ({ habitat, type, header }: AuthProps) => {
             posthog?.identify(user?.attributes?.email, {
               ...user,
               type,
-              habitat
+              habitat,
             });
             posthog?.group('habitat', habitat?.name || 'unknown');
             posthog?.group('type', type || 'unknown');

--- a/src/components/Authentication/Authentication.tsx
+++ b/src/components/Authentication/Authentication.tsx
@@ -1,26 +1,20 @@
-import { Habitat } from 'models';
 import Auth from './Auth';
 import Gallery from './Gallery';
 import GalleryProps from './Gallery/types';
 import styles from './styles.module.css';
 
 interface AuthenticationProps {
-  habitat: Habitat;
   gallery: GalleryProps['data'];
   type: 'applicant' | 'affiliate';
 }
 
-const Authentication = ({ habitat, gallery, type }: AuthenticationProps) => (
+const Authentication = ({ gallery, type }: AuthenticationProps) => {
   <div className={styles.container}>
     <div className={styles.authentification}>
-      <Auth
-        type={type}
-        habitat={habitat}
-        header={habitat?.authenticationHeader || ''}
-      />
+      <Auth type={type} />
     </div>
     {!(type === 'affiliate') && gallery && <Gallery data={gallery} />}
-  </div>
-);
+  </div>;
+};
 
 export default Authentication;

--- a/src/components/Authentication/Authentication.tsx
+++ b/src/components/Authentication/Authentication.tsx
@@ -8,13 +8,13 @@ interface AuthenticationProps {
   type: 'applicant' | 'affiliate';
 }
 
-const Authentication = ({ gallery, type }: AuthenticationProps) => {
+const Authentication = ({ gallery, type }: AuthenticationProps) => (
   <div className={styles.container}>
     <div className={styles.authentification}>
       <Auth type={type} />
     </div>
     {!(type === 'affiliate') && gallery && <Gallery data={gallery} />}
-  </div>;
-};
+  </div>
+);
 
 export default Authentication;

--- a/src/components/HabitatProvider/HabitatProvider.tsx
+++ b/src/components/HabitatProvider/HabitatProvider.tsx
@@ -1,0 +1,16 @@
+import { Habitat } from 'models';
+import React, { useMemo, useState } from 'react';
+import HabitatContext from 'contexts/HabitatContext';
+
+const HabitatProvider = () => {
+  const [habitat, setHabitat] = useState<Habitat>();
+
+  const contextValue = useMemo(
+    () => ({ habitat, setHabitat }),
+    [habitat, setHabitat]
+  );
+
+  return <HabitatContext.Provider value={contextValue} />;
+};
+
+export default HabitatProvider;

--- a/src/components/HabitatProvider/HabitatProvider.tsx
+++ b/src/components/HabitatProvider/HabitatProvider.tsx
@@ -2,7 +2,11 @@ import { Habitat } from 'models';
 import React, { useMemo, useState } from 'react';
 import HabitatContext from 'contexts/HabitatContext';
 
-const HabitatProvider = () => {
+interface IProperties {
+  children: React.ReactNode;
+}
+
+const HabitatProvider = ({ children }: IProperties) => {
   const [habitat, setHabitat] = useState<Habitat>();
 
   const contextValue = useMemo(
@@ -10,7 +14,11 @@ const HabitatProvider = () => {
     [habitat, setHabitat]
   );
 
-  return <HabitatContext.Provider value={contextValue} />;
+  return (
+    <HabitatContext.Provider value={contextValue}>
+      {children}
+    </HabitatContext.Provider>
+  );
 };
 
 export default HabitatProvider;

--- a/src/components/HabitatProvider/index.ts
+++ b/src/components/HabitatProvider/index.ts
@@ -1,0 +1,1 @@
+export { default } from './HabitatProvider';

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -1,9 +1,7 @@
-import { Habitat } from 'models';
 import { MdClose } from 'react-icons/md';
-
 import ProgressBar from 'components/ProgressBar';
-
 import Loading from 'components/Loading';
+import useHabitat from 'hooks/utils/useHabitat';
 import styles from './Header.module.css';
 
 type PageProps = {
@@ -15,13 +13,16 @@ type PageProps = {
 interface HeaderProps {
   current: number;
   pages?: PageProps;
-  habitat?: Habitat;
   cancel?: boolean;
 }
 
-const Header = ({ current, pages, habitat, cancel }: HeaderProps) => {
+const Header = ({ current, pages, cancel }: HeaderProps) => {
+  const { habitat } = useHabitat();
+
   if (!habitat) return <Loading />;
+
   if (!pages) return null;
+
   return (
     <div className={styles.background}>
       <div className={styles.banner}>

--- a/src/contexts/HabitatContext.ts
+++ b/src/contexts/HabitatContext.ts
@@ -1,0 +1,14 @@
+import { Habitat } from 'models';
+import { createContext } from 'react';
+
+interface IHabitatContext {
+  habitat: Habitat | undefined;
+  setHabitat: (habitat: Habitat) => void;
+}
+
+const HabitatContext = createContext<IHabitatContext>({
+  habitat: undefined,
+  setHabitat: () => undefined,
+});
+
+export default HabitatContext;

--- a/src/hooks/utils/useHabitat/index.ts
+++ b/src/hooks/utils/useHabitat/index.ts
@@ -1,0 +1,1 @@
+export { default } from './useHabitat';

--- a/src/hooks/utils/useHabitat/useHabitat.ts
+++ b/src/hooks/utils/useHabitat/useHabitat.ts
@@ -1,0 +1,10 @@
+import HabitatContext from 'contexts/HabitatContext';
+import { useContext } from 'react';
+
+const useHabitat = () => {
+  const { habitat, setHabitat } = useContext(HabitatContext);
+
+  return { habitat, setHabitat };
+};
+
+export default useHabitat;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -10,6 +10,7 @@ import theme from 'styles/theme';
 import 'styles';
 import 'components/Formio';
 
+import HabitatProvider from 'components/HabitatProvider';
 import App from './App';
 import awsExports from './aws-exports';
 
@@ -31,7 +32,9 @@ if (rootElement) {
             apiKey={process.env.REACT_APP_PUBLIC_POSTHOG_KEY}
             options={options}
           >
-            <App />
+            <HabitatProvider>
+              <App />
+            </HabitatProvider>
           </PostHogProvider>
         </ThemeProvider>
       </BrowserRouter>

--- a/src/layouts/ApplicantLayout/ApplicantLayout.jsx
+++ b/src/layouts/ApplicantLayout/ApplicantLayout.jsx
@@ -180,13 +180,7 @@ const HabitatLayout = () => {
   }
 
   if (!userData) {
-    return (
-      <SignUpQuestions
-        habitat={habitat}
-        user={user}
-        setUserData={setUserData}
-      />
-    );
+    return <SignUpQuestions user={user} setUserData={setUserData} />;
   }
 
   return (

--- a/src/layouts/ApplicantLayout/ApplicantLayout.jsx
+++ b/src/layouts/ApplicantLayout/ApplicantLayout.jsx
@@ -1,9 +1,8 @@
 import { useState, useEffect, useCallback } from 'react';
-import { Outlet, useLocation, useParams } from 'react-router-dom';
+import { Outlet, useLocation } from 'react-router-dom';
 import { DataStore, SortDirection } from 'aws-amplify';
 import { useAuthenticator } from '@aws-amplify/ui-react';
 import Authentication from 'components/Authentication';
-import useHabitatByUrlName from 'hooks/services/useHabitatByUrlName';
 import useScrollToTopOnRouteChange from 'hooks/utils/useScrollToTopOnRouteChange';
 import {
   TestApplication,
@@ -14,16 +13,12 @@ import {
 import { DEFAULT_REVIEW_STATUS } from 'utils/constants';
 import { getHabitatOpenCycle } from 'utils/misc';
 import BaseLayout from 'layouts/BaseLayout';
-
+import useHabitat from 'hooks/utils/useHabitat';
 import { AUTHENTICATION_STATUS } from './utils';
 import SignUpQuestions from './SignUpQuestions';
 
 const HabitatLayout = () => {
-  const { habitat: habitatUrlName } = useParams();
-
-  const { habitat } = useHabitatByUrlName({
-    habitatUrlName,
-  });
+  const { habitat } = useHabitat();
 
   const [userData, setUserData] = useState();
 

--- a/src/layouts/ApplicantLayout/ApplicantLayout.jsx
+++ b/src/layouts/ApplicantLayout/ApplicantLayout.jsx
@@ -171,11 +171,7 @@ const HabitatLayout = () => {
 
   if (AUTHENTICATION_STATUS.AUTHENTICATED !== authStatus) {
     return (
-      <Authentication
-        type="applicant"
-        habitat={habitat}
-        gallery={habitat?.props?.gallery}
-      />
+      <Authentication type="applicant" gallery={habitat?.props?.gallery} />
     );
   }
 

--- a/src/layouts/ApplicantLayout/SignUpQuestions/Habitat/Habitat.tsx
+++ b/src/layouts/ApplicantLayout/SignUpQuestions/Habitat/Habitat.tsx
@@ -2,10 +2,9 @@ import { useState } from 'react';
 import { useForm, SubmitHandler } from 'react-hook-form';
 import { DataStore } from 'aws-amplify';
 import { throttle } from 'lodash';
-
 import Footer from 'components/Footer';
-import { Habitat as HabitatModel, User, Sexs, UserTypes } from 'models';
-
+import { User, Sexs, UserTypes } from 'models';
+import useHabitat from 'hooks/utils/useHabitat';
 import styles from '../SignUpQuestions.module.css';
 import dataProps from '../types';
 
@@ -19,7 +18,6 @@ interface HabitatProps {
   data: dataProps;
   setData: React.Dispatch<React.SetStateAction<dataProps>>;
   goBack: () => void;
-  habitat: HabitatModel;
   user: {
     username: string;
   };
@@ -30,7 +28,6 @@ const Habitat = ({
   data,
   setData,
   goBack,
-  habitat,
   user,
   setUserData,
 }: HabitatProps) => {
@@ -39,7 +36,10 @@ const Habitat = ({
     handleSubmit,
     formState: { errors },
   } = useForm<Inputs>();
+
   const [error, setError] = useState<string | null>(null);
+
+  const { habitat } = useHabitat();
 
   const onSubmit: SubmitHandler<Inputs> = async (habitatData) => {
     try {

--- a/src/layouts/ApplicantLayout/SignUpQuestions/SignUpQuestions.tsx
+++ b/src/layouts/ApplicantLayout/SignUpQuestions/SignUpQuestions.tsx
@@ -1,9 +1,7 @@
 import { useState } from 'react';
-
 import Header from 'components/Header';
 import Loading from 'components/Loading';
-import { Habitat as HabitatModel, User } from 'models';
-
+import { User } from 'models';
 import styles from './SignUpQuestions.module.css';
 import General from './General';
 import Household from './Household';
@@ -16,7 +14,6 @@ const initialData: dataProps = {
 };
 
 interface SignUpQuestionsProps {
-  habitat: HabitatModel;
   user: {
     username: string;
   };
@@ -46,11 +43,7 @@ const pages = [
   },
 ];
 
-const SignUpQuestions = ({
-  habitat,
-  user,
-  setUserData,
-}: SignUpQuestionsProps) => {
+const SignUpQuestions = ({ user, setUserData }: SignUpQuestionsProps) => {
   const [data, setData] = useState<dataProps>(initialData);
 
   const goBack = () => {
@@ -60,6 +53,10 @@ const SignUpQuestions = ({
     }));
   };
 
+  if (!user) {
+    return <Loading />;
+  }
+
   const body = [
     <General data={data} setData={setData} />,
     <Household data={data} setData={setData} goBack={goBack} />,
@@ -68,19 +65,14 @@ const SignUpQuestions = ({
       data={data}
       setData={setData}
       goBack={goBack}
-      habitat={habitat}
       user={user}
       setUserData={setUserData}
     />,
   ];
 
-  if (!habitat || !user) {
-    return <Loading />;
-  }
-
   return (
     <div className={styles.page}>
-      <Header habitat={habitat} current={data.current} pages={pages} />
+      <Header current={data.current} pages={pages} />
       {body[data.current]}
     </div>
   );

--- a/src/layouts/BaseLayout/BaseLayout.tsx
+++ b/src/layouts/BaseLayout/BaseLayout.tsx
@@ -1,10 +1,9 @@
 import { useState } from 'react';
-import { useLocation, useParams } from 'react-router-dom';
+import { useLocation } from 'react-router-dom';
 import { useAuthenticator, useBreakpointValue } from '@aws-amplify/ui-react';
 import { getRouteTitle } from 'utils/routes';
 import { useUserQuery } from 'hooks/services';
-import useHabitatByUrlName from 'hooks/services/useHabitatByUrlName';
-import { Habitat, LazyUser } from 'models';
+import { LazyUser } from 'models';
 import { RecursiveModelPredicate } from '@aws-amplify/datastore';
 import TopBar from './components/TopBar';
 import SideBar from './components/SideBar';
@@ -17,14 +16,9 @@ interface IProperties {
 }
 
 const BaseLayout = ({ variation, children, hideSideBar }: IProperties) => {
-  const { habitat: habitatUrlName } = useParams();
-
   const location = useLocation();
-  const title = getRouteTitle(location.pathname);
 
-  const { habitat } = useHabitatByUrlName({
-    habitatUrlName: habitatUrlName || '',
-  });
+  const title = getRouteTitle(location.pathname);
 
   const isMobile = useBreakpointValue({
     base: true,
@@ -72,7 +66,6 @@ const BaseLayout = ({ variation, children, hideSideBar }: IProperties) => {
           expanded={expandSideBar}
           onExpand={handleOnExpand}
           variation={variation}
-          habitat={habitat as unknown as Habitat}
         />
       )}
       <div className={styles.rightSide}>

--- a/src/layouts/BaseLayout/components/SideBar/SideBar.tsx
+++ b/src/layouts/BaseLayout/components/SideBar/SideBar.tsx
@@ -14,7 +14,6 @@ import {
 import useIsHovered from 'hooks/utils/useIsHovered';
 import useCloseContextMenu from 'hooks/utils/useCloseContextMenu';
 import { isCurrentRouteActive, ROUTES } from 'utils/routes';
-import { Habitat } from 'models';
 import MenuItem from './components/MenuItem/MenuItem';
 import style from './SideBar.module.css';
 import HabitatHeader from './components/HabitatHeader';
@@ -25,7 +24,6 @@ interface IProperties {
   onExpand: () => void;
   pathname: string;
   variation: 'applicant' | 'affiliate';
-  habitat: Habitat;
 }
 
 const SideBar = ({
@@ -34,10 +32,11 @@ const SideBar = ({
   onExpand,
   pathname,
   variation,
-  habitat,
 }: IProperties) => {
   const sideBarRef = React.useRef<HTMLDivElement>(null);
+
   const isHovered = useIsHovered(sideBarRef);
+
   useCloseContextMenu(sideBarRef, onExpand);
 
   const isHoveredOrExpanded = isHovered || (mobile && expanded);
@@ -69,7 +68,7 @@ const SideBar = ({
             </Button>
           )}
           <Flex direction="column" gap="16px" justifyContent="space-between">
-            <HabitatHeader habitat={habitat as unknown as Habitat} />
+            <HabitatHeader />
             {variation === 'affiliate' && (
               <>
                 <MenuItem

--- a/src/layouts/BaseLayout/components/SideBar/components/HabitatHeader/HabitatHeader.tsx
+++ b/src/layouts/BaseLayout/components/SideBar/components/HabitatHeader/HabitatHeader.tsx
@@ -1,13 +1,11 @@
 import { Flex, Image, Text } from '@aws-amplify/ui-react';
 import habitatLogo from 'assets/images/habitatlogowhite.svg';
 import SidebarLogoWithoutProps from 'assets/images/sidebar-logo-without-props.png';
-import { Habitat } from 'models';
+import useHabitat from 'hooks/utils/useHabitat';
 
-interface IProperties {
-  habitat: Habitat;
-}
+const HabitatHeader = () => {
+  const { habitat } = useHabitat();
 
-const HabitatHeader = ({ habitat }: IProperties) => {
   const habitatName = habitat?.props?.sidebarName?.name;
 
   return habitatName !== '' ? (

--- a/src/layouts/HabitatLayout/HabitatLayout.tsx
+++ b/src/layouts/HabitatLayout/HabitatLayout.tsx
@@ -1,14 +1,71 @@
-import { Outlet } from 'react-router-dom';
-import { Authenticator } from '@aws-amplify/ui-react';
-
+import { Outlet, useParams } from 'react-router-dom';
+import { Authenticator, Flex, Text } from '@aws-amplify/ui-react';
 import CheckMaintenance from 'layouts/Maintenance/CheckMaintenance';
+import useHabitat from 'hooks/utils/useHabitat';
+import { useEffect, useState } from 'react';
+import { DataStore } from 'aws-amplify';
+import { Habitat } from 'models';
 
-const HabitatLayout = () => (
-  <CheckMaintenance>
-    <Authenticator.Provider>
-      <Outlet />
-    </Authenticator.Provider>
-  </CheckMaintenance>
-);
+const HabitatLayout = () => {
+  const { habitat, setHabitat } = useHabitat();
+
+  const [isLoading, setIsLoading] = useState(0);
+
+  const { habitat: habitatUrlName } = useParams();
+
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        setIsLoading((prevIsLoading) => prevIsLoading + 1);
+        const habitatsResponse = await DataStore.query(Habitat, (c) =>
+          c.urlName.eq(habitatUrlName)
+        );
+
+        const habitatObject = habitatsResponse[0];
+
+        setHabitat(habitatObject);
+        setIsLoading((prevIsLoading) => prevIsLoading - 1);
+      } catch (error) {
+        console.log(`Error fetching habitat: ${error}`);
+      }
+    };
+
+    fetchData();
+  }, [habitatUrlName, setHabitat]);
+
+  if (isLoading) {
+    return (
+      <Flex
+        direction="column"
+        height="100vh"
+        alignItems="center"
+        padding="16px"
+      >
+        <Text>Loading...</Text>
+      </Flex>
+    );
+  }
+
+  if (!habitat) {
+    return (
+      <Flex
+        direction="column"
+        height="100vh"
+        alignItems="center"
+        padding="16px"
+      >
+        <Text>Habitat not found.</Text>
+      </Flex>
+    );
+  }
+
+  return (
+    <CheckMaintenance>
+      <Authenticator.Provider>
+        <Outlet />
+      </Authenticator.Provider>
+    </CheckMaintenance>
+  );
+};
 
 export default HabitatLayout;

--- a/src/layouts/NewAffiliateLayout/NewAffiliateLayout.jsx
+++ b/src/layouts/NewAffiliateLayout/NewAffiliateLayout.jsx
@@ -76,7 +76,7 @@ const NewAffiliateLayout = () => {
   }
 
   if (AUTHENTICATION_STATUS.AUTHENTICATED !== authStatus) {
-    return <Authentication type="affiliate" habitat={habitat} />;
+    return <Authentication type="affiliate" />;
   }
 
   if (!userData) {

--- a/src/layouts/NewAffiliateLayout/NewAffiliateLayout.jsx
+++ b/src/layouts/NewAffiliateLayout/NewAffiliateLayout.jsx
@@ -1,25 +1,17 @@
 import { useEffect, useState } from 'react';
-import {
-  Outlet,
-  useParams,
-  useOutlet,
-  useNavigate,
-  Navigate,
-} from 'react-router-dom';
+import { Outlet, useOutlet, useNavigate, Navigate } from 'react-router-dom';
 import { DataStore } from 'aws-amplify';
-
 import { Flex, Text, useAuthenticator } from '@aws-amplify/ui-react';
-
 import Authentication from 'components/Authentication';
 import BaseLayout from 'layouts/BaseLayout';
-import { Habitat, User } from 'models';
+import { User } from 'models';
 import { AUTHENTICATION_STATUS } from 'utils/constants';
-
+import useHabitat from 'hooks/utils/useHabitat';
 import SignUpQuestions from './SignUpQuestions';
 import style from './NewAffiliateLayout.module.css';
 
 const NewAffiliateLayout = () => {
-  const [habitat, setHabitat] = useState(null);
+  const { habitat, setHabitat } = useHabitat();
   const [isUserAllowed, setIsUserAllowed] = useState(false);
   const [isLoading, setIsLoading] = useState(0);
   const { authStatus, user } = useAuthenticator((context) => [
@@ -30,27 +22,17 @@ const NewAffiliateLayout = () => {
   const outlet = useOutlet();
   const navigate = useNavigate();
 
-  const habitatUrlName = useParams('habitat').habitat;
-
   useEffect(() => {
     if (!outlet) {
       navigate(`./home`);
     }
-  }, [outlet, navigate, habitatUrlName]);
+  }, [outlet, navigate]);
 
   useEffect(() => {
     const fetchData = async () => {
       setIsLoading((previousIsLoading) => previousIsLoading + 1);
       try {
-        const habitatsResponse = await DataStore.query(Habitat, (c) =>
-          c.urlName.eq(habitatUrlName)
-        );
-
-        const habitatObject = habitatsResponse[0];
-
-        setHabitat(habitatObject);
-
-        const allowedUsers = habitatObject.users || [];
+        const allowedUsers = habitat.users || [];
 
         if (user && allowedUsers.includes(user.username)) {
           setIsUserAllowed(true);
@@ -64,7 +46,7 @@ const NewAffiliateLayout = () => {
     };
 
     fetchData();
-  }, [habitatUrlName, user, authStatus]);
+  }, [user, authStatus, setHabitat, habitat]);
 
   useEffect(() => {
     const getUserData = async () => {

--- a/src/layouts/NewAffiliateLayout/NewAffiliateLayout.jsx
+++ b/src/layouts/NewAffiliateLayout/NewAffiliateLayout.jsx
@@ -82,7 +82,6 @@ const NewAffiliateLayout = () => {
   if (!userData) {
     return (
       <SignUpQuestions
-        habitat={habitat}
         user={user}
         setUserData={setUserData}
         isUserAllowed={isUserAllowed}

--- a/src/layouts/NewAffiliateLayout/SignUpQuestions/Affiliate/Affiliate.tsx
+++ b/src/layouts/NewAffiliateLayout/SignUpQuestions/Affiliate/Affiliate.tsx
@@ -2,11 +2,10 @@ import { useState } from 'react';
 import { useForm, SubmitHandler } from 'react-hook-form';
 import { DataStore } from 'aws-amplify';
 import { throttle } from 'lodash';
-
 import Footer from 'components/Footer';
-import { Habitat as HabitatModel, Sexs, User, UserTypes } from 'models';
-
+import { Sexs, User, UserTypes } from 'models';
 import { MdArrowDropDown } from 'react-icons/md';
+import useHabitat from 'hooks/utils/useHabitat';
 import styles from '../SignUpQuestions.module.css';
 import dataProps from '../types';
 import months from '../utils/months';
@@ -23,25 +22,21 @@ interface AffiliateProps {
   data: dataProps;
   setData: React.Dispatch<React.SetStateAction<dataProps>>;
   goBack: () => void;
-  habitat: HabitatModel;
   user: {
     username: string;
   };
 }
 
-const Affiliate = ({
-  data,
-  setData,
-  goBack,
-  habitat,
-  user,
-}: AffiliateProps) => {
+const Affiliate = ({ data, setData, goBack, user }: AffiliateProps) => {
   const {
     register,
     handleSubmit,
     formState: { errors },
   } = useForm<Inputs>();
+
   const [error, setError] = useState<string | null>(null);
+
+  const { habitat } = useHabitat();
 
   const onSubmit: SubmitHandler<Inputs> = async (affiliateData) => {
     try {

--- a/src/layouts/NewAffiliateLayout/SignUpQuestions/SignUpQuestions.tsx
+++ b/src/layouts/NewAffiliateLayout/SignUpQuestions/SignUpQuestions.tsx
@@ -1,8 +1,7 @@
 import { useState } from 'react';
-
 import Header from 'components/Header';
 import Loading from 'components/Loading';
-
+import useHabitat from 'hooks/utils/useHabitat';
 import styles from './SignUpQuestions.module.css';
 import General from './General';
 import Affiliate from './Affiliate';
@@ -14,12 +13,10 @@ const initialData: dataProps = {
   current: 0,
 };
 
-const SignUpQuestions = ({
-  habitat,
-  user,
-  isUserAllowed,
-}: SignUpQuestionsProps) => {
+const SignUpQuestions = ({ user, isUserAllowed }: SignUpQuestionsProps) => {
   const [data, setData] = useState<dataProps>(initialData);
+
+  const { habitat } = useHabitat();
 
   const goBack = () => {
     setData((prev) => ({
@@ -30,13 +27,7 @@ const SignUpQuestions = ({
 
   const body = [
     <General data={data} setData={setData} />,
-    <Affiliate
-      data={data}
-      setData={setData}
-      goBack={goBack}
-      habitat={habitat}
-      user={user}
-    />,
+    <Affiliate data={data} setData={setData} goBack={goBack} user={user} />,
     <Confirmation
       name={habitat?.urlName}
       longName={habitat?.longName}
@@ -44,13 +35,13 @@ const SignUpQuestions = ({
     />,
   ];
 
-  if (!habitat || !user) {
+  if (!user) {
     return <Loading />;
   }
 
   return (
     <div className={styles.page}>
-      <Header habitat={habitat} current={data.current} pages={pages} />
+      <Header current={data.current} pages={pages} />
       {body[data.current]}
     </div>
   );

--- a/src/layouts/NewAffiliateLayout/SignUpQuestions/types.ts
+++ b/src/layouts/NewAffiliateLayout/SignUpQuestions/types.ts
@@ -1,5 +1,3 @@
-import { type Habitat, type User } from 'models';
-
 interface dataProps {
   current: number;
   general?: {
@@ -18,7 +16,6 @@ interface dataProps {
 }
 
 export interface SignUpQuestionsProps {
-  habitat: Habitat;
   isUserAllowed: boolean;
   user: {
     username: string;

--- a/src/pages/[habitat]/affiliate/cycles/[cycleId]/AffiliateCycleApplications.tsx
+++ b/src/pages/[habitat]/affiliate/cycles/[cycleId]/AffiliateCycleApplications.tsx
@@ -11,7 +11,6 @@ import {
   SubmissionStatus,
   LazyTestApplication,
   TestApplication,
-  Habitat,
   ApplicationTypes,
 } from 'models';
 import { useState } from 'react';
@@ -49,7 +48,7 @@ const AffiliateCycleApplications = () => {
   });
   const { cycleId } = useParams();
 
-  const { habitat, setHabitat } = useHabitat();
+  const { habitat } = useHabitat();
 
   const [statusModalOpen, setStatusModalOpen] = useState(false);
 
@@ -223,7 +222,6 @@ const AffiliateCycleApplications = () => {
           <NewApplicationModal
             open={newApplicationOpen}
             onClose={handleOnCloseNewApplicationModal}
-            habitat={habitat}
             cycle={cycle}
             setTrigger={setTrigger}
           />
@@ -239,8 +237,6 @@ const AffiliateCycleApplications = () => {
       <StatusModal
         open={statusModalOpen}
         onClose={handleOnCloseStatusModal}
-        habitat={habitat}
-        setHabitat={setHabitat}
         setTrigger={setTrigger}
       />
       <TableWithPaginator

--- a/src/pages/[habitat]/affiliate/cycles/[cycleId]/AffiliateCycleApplications.tsx
+++ b/src/pages/[habitat]/affiliate/cycles/[cycleId]/AffiliateCycleApplications.tsx
@@ -21,12 +21,7 @@ import {
   MdOutlineLink,
   MdOutlineOpenInNew,
 } from 'react-icons/md';
-import {
-  Link,
-  useLocation,
-  useOutletContext,
-  useParams,
-} from 'react-router-dom';
+import { Link, useLocation, useParams } from 'react-router-dom';
 import { stringToHumanReadable } from 'utils/strings';
 import IconButton from 'components/IconButton';
 import BreadCrumbs from 'components/BreadCrumbs/BreadCrumbs';
@@ -34,9 +29,9 @@ import DropdownMenu from 'components/DropdownMenu';
 import GoBack from 'components/GoBack';
 import { DEFAULT_REVIEW_STATUS } from 'utils/constants';
 import { useBreakpointValue } from '@aws-amplify/ui-react';
-
 import { convertDateYYYYMMDDtoDDMMYYYY } from 'utils/dates';
 import StatusChip from 'components/StatusChip';
+import useHabitat from 'hooks/utils/useHabitat';
 import style from './AffiliateCycleApplications.module.css';
 import NewApplicationModal from './components/NewApplicationModal';
 import StatusModal from './components/StatusModal';
@@ -45,24 +40,25 @@ import Filters from './components/Filters';
 import Username from './components/Username';
 import { handleCopyToClipboard } from './utils';
 
-interface IOutletContext {
-  habitat?: Habitat;
-  setHabitat: (habitat: Habitat) => void;
-}
-
 const AffiliateCycleApplications = () => {
   const { pathname } = useLocation();
+
   const isSmall = useBreakpointValue({
     base: true,
     medium: false,
   });
   const { cycleId } = useParams();
-  const { habitat, setHabitat } = useOutletContext<IOutletContext>();
+
+  const { habitat, setHabitat } = useHabitat();
+
   const [statusModalOpen, setStatusModalOpen] = useState(false);
+
   const [newApplicationOpen, setNewApplicationOpen] = useState(false);
+
   const [trigger, setTrigger] = useState(0);
 
   const [filterModal, setFilterModal] = useState(false);
+
   const [filters, setFilters] = useState<Inputs>({
     startDateSubmitted: '',
     endDateSubmitted: '',
@@ -70,6 +66,7 @@ const AffiliateCycleApplications = () => {
     reviewStatus: null,
     customStatus: '',
   });
+
   const { data: applications }: { data: TestApplication[] } =
     useTestApplicationsQuery({
       criteria: (c1: RecursiveModelPredicate<LazyTestApplication>) =>

--- a/src/pages/[habitat]/affiliate/cycles/[cycleId]/[applicationId]/AffiliateApplicationDetailsPage.tsx
+++ b/src/pages/[habitat]/affiliate/cycles/[cycleId]/[applicationId]/AffiliateApplicationDetailsPage.tsx
@@ -341,9 +341,7 @@ const AffiliateApplicationDetailsPage = () => {
               handleOnSaveNote={handleOnSaveNote}
             />
           )}
-          {activeTab === 2 && (
-            <DecisionsTab decisions={decisions} habitat={habitat} />
-          )}
+          {activeTab === 2 && <DecisionsTab decisions={decisions} />}
           {activeTab === 3 && <CalculationsTab formAnswers={formAnswers} />}
         </div>
       </div>

--- a/src/pages/[habitat]/affiliate/cycles/[cycleId]/[applicationId]/AffiliateApplicationDetailsPage.tsx
+++ b/src/pages/[habitat]/affiliate/cycles/[cycleId]/[applicationId]/AffiliateApplicationDetailsPage.tsx
@@ -6,7 +6,7 @@ import {
   MdOutlineNoteAlt,
   MdOutlineTextSnippet,
 } from 'react-icons/md';
-import { useNavigate, useOutletContext, useParams } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router-dom';
 import {
   useDecisionsQuery,
   useFormAnswersQuery,
@@ -23,7 +23,6 @@ import {
   TestApplication,
   TestCycle,
   ReviewStatus,
-  Habitat,
   LazyDecision,
   ApplicationTypes,
   SubmissionStatus,
@@ -40,6 +39,7 @@ import { EditorState } from 'lexical';
 import { useAuthenticator } from '@aws-amplify/ui-react';
 import Loading from 'components/Loading';
 import { usePostHog } from 'posthog-js/react';
+import useHabitat from 'hooks/utils/useHabitat';
 import style from './AffiliateApplicationDetailsPage.module.css';
 import LocalNavigation from './components/LocalNavigation';
 import ApplicationTab from './components/ApplicationTab';
@@ -64,7 +64,7 @@ const AffiliateApplicationDetailsPage = () => {
 
   const { applicationId } = useParams();
 
-  const { habitat }: { habitat?: Habitat } = useOutletContext();
+  const { habitat } = useHabitat();
 
   const { user } = useAuthenticator((context) => [context.user]);
 

--- a/src/pages/[habitat]/affiliate/cycles/[cycleId]/[applicationId]/components/DecisionsTab/DecisionsTab.tsx
+++ b/src/pages/[habitat]/affiliate/cycles/[cycleId]/[applicationId]/components/DecisionsTab/DecisionsTab.tsx
@@ -2,32 +2,36 @@ import DecisionCard from 'components/DecisionCard';
 import { ReviewStatus, Decision, Habitat } from 'models';
 import React from 'react';
 import { Text } from '@aws-amplify/ui-react';
+import useHabitat from 'hooks/utils/useHabitat';
 import style from './DecisionsTab.module.css';
 
 interface IProperties {
-  habitat?: Habitat;
   decisions: Decision[];
 }
 
-const DecisionsTab = ({ habitat, decisions }: IProperties) => (
-  <div className={style.container}>
-    {decisions.length > 0 ? (
-      decisions.map((decision) => (
-        <DecisionCard
-          key={decision.id}
-          date={decision.createdAt || ''}
-          habitat={habitat?.longName || ''}
-          status={decision.status as keyof typeof ReviewStatus}
-          editorState={decision.serializedEditorState}
-          shouldRenderStatusChip
-        />
-      ))
-    ) : (
-      <Text textAlign="center" fontWeight="bold">
-        There are no decisions for this application
-      </Text>
-    )}
-  </div>
-);
+const DecisionsTab = ({ decisions }: IProperties) => {
+  const { habitat } = useHabitat();
+
+  return (
+    <div className={style.container}>
+      {decisions.length > 0 ? (
+        decisions.map((decision) => (
+          <DecisionCard
+            key={decision.id}
+            date={decision.createdAt || ''}
+            habitat={habitat?.longName || ''}
+            status={decision.status as keyof typeof ReviewStatus}
+            editorState={decision.serializedEditorState}
+            shouldRenderStatusChip
+          />
+        ))
+      ) : (
+        <Text textAlign="center" fontWeight="bold">
+          There are no decisions for this application
+        </Text>
+      )}
+    </div>
+  );
+};
 
 export default DecisionsTab;

--- a/src/pages/[habitat]/affiliate/cycles/[cycleId]/components/NewApplicationModal/NewApplicationModal.jsx
+++ b/src/pages/[habitat]/affiliate/cycles/[cycleId]/components/NewApplicationModal/NewApplicationModal.jsx
@@ -21,9 +21,11 @@ import {
 } from 'models';
 import CustomButton from 'components/CustomButton/CustomButton';
 import { stringToHumanReadable } from 'utils/strings';
+import useHabitat from 'hooks/utils/useHabitat';
 import { newPaperApplicationSchema } from './NewApplicationModal.schema';
 
-const NewApplicationModal = ({ open, onClose, setTrigger, habitat, cycle }) => {
+const NewApplicationModal = ({ open, onClose, setTrigger, cycle }) => {
+  const { habitat } = useHabitat();
   const [showError, setShowError] = useState(false);
   const [loading, setLoading] = useState(0);
   const {
@@ -218,7 +220,6 @@ NewApplicationModal.propTypes = {
   open: PropTypes.bool,
   onClose: PropTypes.func,
   setTrigger: PropTypes.func,
-  habitat: PropTypes.object,
   cycle: PropTypes.object,
 };
 

--- a/src/pages/[habitat]/affiliate/cycles/[cycleId]/components/StatusModal/StatusModal.jsx
+++ b/src/pages/[habitat]/affiliate/cycles/[cycleId]/components/StatusModal/StatusModal.jsx
@@ -18,8 +18,10 @@ import React, { useCallback, useMemo, useState } from 'react';
 import { MdAdd, MdCheck, MdClose, MdDelete, MdEdit } from 'react-icons/md';
 import { DEFAULT_REVIEW_STATUS } from 'utils/constants';
 import PropTypes from 'prop-types';
+import useHabitat from 'hooks/utils/useHabitat';
 
-const StatusModal = ({ open, onClose, habitat, setHabitat, setTrigger }) => {
+const StatusModal = ({ open, onClose, setTrigger }) => {
+  const { habitat, setHabitat } = useHabitat();
   const [editingStatus, setEditingStatus] = useState();
   const [editingAlert, setEditingAlert] = useState(false);
   const [deletingStatus, setDeletingStatus] = useState();
@@ -345,8 +347,6 @@ const StatusModal = ({ open, onClose, habitat, setHabitat, setTrigger }) => {
 StatusModal.propTypes = {
   open: PropTypes.bool,
   onClose: PropTypes.func,
-  habitat: PropTypes.object,
-  setHabitat: PropTypes.func,
   setTrigger: PropTypes.func,
 };
 

--- a/src/pages/[habitat]/affiliate/cycles/components/newCycle/newCycle.tsx
+++ b/src/pages/[habitat]/affiliate/cycles/components/newCycle/newCycle.tsx
@@ -4,14 +4,14 @@ import { Button } from '@aws-amplify/ui-react';
 import { throttle } from 'lodash';
 import dayjs from 'dayjs';
 import Modal from 'components/Modal';
-import { Habitat, RootForm, TestCycle } from 'models';
+import { RootForm, TestCycle } from 'models';
+import useHabitat from 'hooks/utils/useHabitat';
 import styles from './newCycle.module.css';
 
 interface NewCycleProps {
   open: boolean;
   close: () => void;
   openCycle?: TestCycle;
-  habitat?: Habitat;
   refetch: () => void;
   rootForm: RootForm | null;
 }
@@ -24,15 +24,17 @@ const NewCycle = ({
   open,
   close,
   openCycle,
-  habitat,
   refetch,
   rootForm,
 }: NewCycleProps) => {
+  const { habitat } = useHabitat();
+
   const {
     register,
     handleSubmit,
     formState: { errors },
   } = useForm<Inputs>();
+
   const onCloseCycle = async () => {
     if (openCycle) {
       const originalOpenCycle = await DataStore.query(TestCycle, openCycle.id);
@@ -48,6 +50,7 @@ const NewCycle = ({
       }
     }
   };
+
   const onCreateCycle: SubmitHandler<Inputs> = async (data) => {
     if (habitat && rootForm && rootForm.formUrls.length > 0) {
       await DataStore.save(
@@ -67,6 +70,7 @@ const NewCycle = ({
       close();
     }
   };
+
   return (
     <Modal
       title={openCycle ? 'Close Application Cycle' : 'Create Application Cycle'}

--- a/src/pages/[habitat]/affiliate/cycles/page.tsx
+++ b/src/pages/[habitat]/affiliate/cycles/page.tsx
@@ -230,7 +230,6 @@ const CyclesPage = () => {
             value.openCycles.length > 0 ? value.openCycles[0] : undefined
           }
           rootForm={rootForm}
-          habitat={habitat}
           open={showModal}
           close={() => setShowModal(false)}
         />

--- a/src/pages/[habitat]/affiliate/cycles/page.tsx
+++ b/src/pages/[habitat]/affiliate/cycles/page.tsx
@@ -1,10 +1,9 @@
 import { useCallback, useState } from 'react';
-import { useNavigate, useOutletContext, useParams } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router-dom';
 import { DataStore, SortDirection } from 'aws-amplify';
 import { Button } from '@aws-amplify/ui-react';
 import { MdOutlineOpenInNew, MdFilterList } from 'react-icons/md';
 import { throttle } from 'lodash';
-
 import BreadCrumbs from 'components/BreadCrumbs/BreadCrumbs';
 import Chip from 'components/Chip';
 import Loading from 'components/Loading';
@@ -13,27 +12,27 @@ import GoBack from 'components/GoBack';
 import TableWithPaginator from 'components/TableWithPaginator';
 import { useRootFormById } from 'hooks/services';
 import useAsync from 'hooks/utils/useAsync/useAsync';
-import { Habitat, RootForm, TestCycle } from 'models';
+import { RootForm, TestCycle } from 'models';
 import { convertDateYYYYMMDDtoDDMMYYYY } from 'utils/dates';
 import { Status } from 'utils/enums';
-
+import useHabitat from 'hooks/utils/useHabitat';
 import Filters from './components/filters';
 import NewCycle from './components/newCycle';
 import styles from './styles.module.css';
 import headers from './utils/headers';
 import { Inputs } from './types';
 
-interface OutletContextProps {
-  habitat?: Habitat;
-}
-
 const CyclesPage = () => {
   const navigate = useNavigate();
+
   const { formId } = useParams();
-  const context = useOutletContext<OutletContextProps>();
-  const habitat = context?.habitat;
+
+  const { habitat } = useHabitat();
+
   const [showFilters, setShowFilters] = useState(false);
+
   const [showModal, setShowModal] = useState(false);
+
   const [filters, setFilters] = useState<Inputs>({
     startDate: '',
     endDate: '',

--- a/src/pages/[habitat]/affiliate/forms/AffiliateFormsPage.tsx
+++ b/src/pages/[habitat]/affiliate/forms/AffiliateFormsPage.tsx
@@ -7,11 +7,11 @@ import TableWithPaginator from 'components/TableWithPaginator';
 import Chip from 'components/Chip';
 import { stringToHumanReadable } from 'utils/strings';
 import Toggle from 'components/Toggle';
-import { Habitat } from 'models';
 import { useRootFormsQuery } from 'hooks/services';
-import { useNavigate, useOutletContext } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 import { dateOnly } from 'utils/dates';
 import { throttle } from 'lodash';
+import useHabitat from 'hooks/utils/useHabitat';
 import style from './AffiliateFormsPage.module.css';
 import NewFormButton from './components/NewFormButton';
 
@@ -34,12 +34,8 @@ const AffiliateFormsPage = () => {
   localStorage.removeItem('goto');
 
   // Get context
-  interface OutletContextType {
-    habitat: Habitat;
-  }
 
-  const context = useOutletContext<OutletContextType>();
-  const { habitat } = context;
+  const { habitat } = useHabitat();
 
   // Get Forms
   const { data: forms } = useRootFormsQuery({

--- a/src/pages/[habitat]/affiliate/forms/components/NewFormButton/NewFormButton.tsx
+++ b/src/pages/[habitat]/affiliate/forms/components/NewFormButton/NewFormButton.tsx
@@ -16,9 +16,9 @@ import {
 import { useState } from 'react';
 import FileInput from 'components/FileInput';
 import { DataStore } from '@aws-amplify/datastore';
-import { Habitat, RootForm, RootFormStatusTypes } from 'models';
-import { useOutletContext } from 'react-router-dom';
+import { RootForm, RootFormStatusTypes } from 'models';
 import { API, Storage } from 'aws-amplify';
+import useHabitat from 'hooks/utils/useHabitat';
 
 const EMAIL_S3_BUCKET = process.env.REACT_APP_EMAIL_S3_BUCKET;
 
@@ -39,12 +39,8 @@ function NewFormButton({ triggerUpdate }: IProperties) {
   });
 
   // Get context
-  interface OutletContextType {
-    habitat: Habitat;
-  }
 
-  const context = useOutletContext<OutletContextType>();
-  const { habitat } = context;
+  const { habitat } = useHabitat();
 
   // onChange
   const handleOnChange = (newFiles: any) => {
@@ -71,6 +67,11 @@ function NewFormButton({ triggerUpdate }: IProperties) {
   // Submit handler
   async function handleSubmit(event: any) {
     event.preventDefault();
+
+    if (!habitat) {
+      return;
+    }
+
     setLoading(true);
     const formData = new FormData(event.target);
     const formDataObject = Object.fromEntries(formData.entries());

--- a/src/pages/[habitat]/applicant/[cycleId]/ApplicantCyclePage.tsx
+++ b/src/pages/[habitat]/applicant/[cycleId]/ApplicantCyclePage.tsx
@@ -186,7 +186,7 @@ const ApplicantCyclePage = () => {
           />
           <div className={style.tabContainer}>
             {activeTab === 0 && (
-              <Form habitat={habitat} application={application} cycle={cycle} />
+              <Form application={application} cycle={cycle} />
             )}
             {activeTab === 1 && <Decisions application={application} />}
           </div>
@@ -195,14 +195,7 @@ const ApplicantCyclePage = () => {
     );
   }
 
-  return (
-    <Form
-      habitat={habitat}
-      application={application}
-      cycle={cycle}
-      formContainer={false}
-    />
-  );
+  return <Form application={application} cycle={cycle} formContainer={false} />;
 };
 
 export default ApplicantCyclePage;

--- a/src/pages/[habitat]/applicant/[cycleId]/ApplicantCyclePage.tsx
+++ b/src/pages/[habitat]/applicant/[cycleId]/ApplicantCyclePage.tsx
@@ -163,11 +163,7 @@ const ApplicantCyclePage = () => {
   ) {
     return (
       <div className={`${style.page}`}>
-        <SuccesfullySubmitted
-          habitat={habitat}
-          onReview={onReview}
-          application={application}
-        />
+        <SuccesfullySubmitted onReview={onReview} application={application} />
       </div>
     );
   }

--- a/src/pages/[habitat]/applicant/[cycleId]/ApplicantCyclePage.tsx
+++ b/src/pages/[habitat]/applicant/[cycleId]/ApplicantCyclePage.tsx
@@ -1,31 +1,26 @@
 import { Loader, useAuthenticator } from '@aws-amplify/ui-react';
-import { useLocation, useOutletContext, useParams } from 'react-router-dom';
+import { useLocation, useParams } from 'react-router-dom';
 import {
-  Habitat,
   SubmissionStatus,
   TestApplication,
   TestCycle,
   ReviewStatus,
   ApplicationTypes,
-  User,
 } from 'models';
 import { MdOutlineNoteAlt, MdOutlineLibraryAddCheck } from 'react-icons/md';
 import { useCallback, useEffect, useState } from 'react';
 import { DataStore, SortDirection } from 'aws-amplify';
 import { useTestCycleById } from 'hooks/services';
 import LocalNavigation from 'pages/[habitat]/affiliate/cycles/[cycleId]/[applicationId]/components/LocalNavigation';
+import useHabitat from 'hooks/utils/useHabitat';
 import Form from './components/Form/Form';
 import SuccesfullySubmitted from './components/SuccesfullySubmitted';
 import NoOpenCycle from './components/NoOpenCycle';
 import style from './ApplicantCyclePage.module.css';
 import Decisions from './components/Tabs/Decisions';
 
-interface IOutletContext {
-  habitat?: Habitat;
-}
-
 const ApplicantCyclePage = () => {
-  const { habitat }: IOutletContext = useOutletContext();
+  const { habitat } = useHabitat();
 
   const { cycleId } = useParams();
 
@@ -83,7 +78,6 @@ const ApplicantCyclePage = () => {
               ownerID: username,
               lastPage: 0,
               lastSection: location.pathname,
-              members: [],
               submissionStatus: SubmissionStatus.INCOMPLETE,
               reviewStatus: ReviewStatus.PENDING,
               submittedDate: '0001-01-01',

--- a/src/pages/[habitat]/applicant/[cycleId]/components/Form/Form.tsx
+++ b/src/pages/[habitat]/applicant/[cycleId]/components/Form/Form.tsx
@@ -20,12 +20,12 @@ import { usePostHog } from 'posthog-js/react';
 import { Button, Flex, Text } from '@aws-amplify/ui-react';
 import CustomButton from 'components/CustomButton/CustomButton';
 import { RecursiveModelPredicate } from '@aws-amplify/datastore';
+import useHabitat from 'hooks/utils/useHabitat';
 import uploadSubmission from './services/uploadSubmission';
 import style from './Form.module.css';
 import FormLayout from './layouts/FormLayout';
 
 interface IProperties {
-  habitat?: Habitat;
   application?: TestApplication;
   cycle?: TestCycle;
   formContainer?: boolean;
@@ -33,12 +33,8 @@ interface IProperties {
 
 const FORMIO_URL = process.env.REACT_APP_FORMIO_URL;
 
-const Form = ({
-  habitat,
-  application,
-  cycle,
-  formContainer = true,
-}: IProperties) => {
+const Form = ({ application, cycle, formContainer = true }: IProperties) => {
+  const { habitat } = useHabitat();
   const [reviewMode, setReviewMode] = useState(false);
   const [formReady, setFormReady] = useState<typeof Wizard>();
   const posthog = usePostHog();
@@ -198,7 +194,6 @@ const Form = ({
           ) : (
             <FormLayout
               formReady={formReady}
-              habitat={habitat}
               application={application}
               cycle={cycle}
             >

--- a/src/pages/[habitat]/applicant/[cycleId]/components/Form/layouts/FormLayout/FormLayout.tsx
+++ b/src/pages/[habitat]/applicant/[cycleId]/components/Form/layouts/FormLayout/FormLayout.tsx
@@ -168,7 +168,7 @@ const FormLayout = ({
       {!formReady && <Loading />}
       {formReady && (
         <div ref={headerRef}>
-          <Header current={currentPage} pages={pages} habitat={habitat} />
+          <Header current={currentPage} pages={pages} />
         </div>
       )}
       <div className={styles.body}>{children}</div>

--- a/src/pages/[habitat]/applicant/[cycleId]/components/Form/layouts/FormLayout/FormLayout.tsx
+++ b/src/pages/[habitat]/applicant/[cycleId]/components/Form/layouts/FormLayout/FormLayout.tsx
@@ -6,6 +6,7 @@ import { formatHabitatCycleApplicationData } from 'utils/formatters';
 import { Header, Footer, Loading } from 'components';
 import { DataStore } from 'aws-amplify';
 import { TestApplication } from 'models';
+import useHabitat from 'hooks/utils/useHabitat';
 import getPage from './utils/getPage';
 
 import FormLayoutProps from './FormLayout.types';
@@ -13,11 +14,12 @@ import styles from './FormLayout.module.css';
 
 const FormLayout = ({
   formReady,
-  habitat,
   children,
   application,
   cycle,
 }: FormLayoutProps) => {
+  const { habitat } = useHabitat();
+
   const posthog = usePostHog();
 
   const [currentPage, setCurrentPage] = useState(0);

--- a/src/pages/[habitat]/applicant/[cycleId]/components/Form/layouts/FormLayout/FormLayout.types.ts
+++ b/src/pages/[habitat]/applicant/[cycleId]/components/Form/layouts/FormLayout/FormLayout.types.ts
@@ -1,12 +1,11 @@
 import { ReactNode } from 'react';
 
-import { Habitat, TestApplication, TestCycle } from 'models';
+import { TestApplication, TestCycle } from 'models';
 
 import { Wizard } from '@formio/react';
 
 interface FormLayoutProps {
   formReady?: typeof Wizard;
-  habitat?: Habitat;
   children: ReactNode;
   application?: TestApplication;
   cycle?: TestCycle;

--- a/src/pages/[habitat]/applicant/[cycleId]/components/SuccesfullySubmitted.tsx
+++ b/src/pages/[habitat]/applicant/[cycleId]/components/SuccesfullySubmitted.tsx
@@ -1,26 +1,22 @@
 import { Link } from 'react-router-dom';
 import { Flex, Text } from '@aws-amplify/ui-react';
-import { Habitat, RootForm, TestApplication, TestCycle } from 'models';
-
+import { RootForm, TestApplication, TestCycle } from 'models';
 import CustomButton from 'components/CustomButton/CustomButton';
 import CustomCard from 'components/CustomCard';
-
 import { useEffect, useState } from 'react';
 import { DataStore } from 'aws-amplify';
 import { unknown } from 'zod';
+import useHabitat from 'hooks/utils/useHabitat';
 import styles from './SuccesfullySubmitted.module.css';
 
 interface IProperties {
-  habitat?: Habitat;
   onReview: () => void;
   application?: TestApplication;
 }
 
-const SuccesfullySubmitted = ({
-  habitat,
-  onReview,
-  application,
-}: IProperties) => {
+const SuccesfullySubmitted = ({ onReview, application }: IProperties) => {
+  const { habitat } = useHabitat();
+
   const [rootForm, setRootForm] = useState<RootForm | undefined>(undefined);
 
   useEffect(() => {

--- a/src/pages/[habitat]/applicant/[cycleId]/components/Tabs/Decisions.tsx
+++ b/src/pages/[habitat]/applicant/[cycleId]/components/Tabs/Decisions.tsx
@@ -1,5 +1,3 @@
-import { useOutletContext } from 'react-router-dom';
-
 import { Flex, Text } from '@aws-amplify/ui-react';
 import {
   RecursiveModelPredicate,
@@ -8,19 +6,16 @@ import {
 } from '@aws-amplify/datastore';
 import DecisionCard from 'components/DecisionCard';
 import { useDecisionsQuery } from 'hooks/services';
-import { Decision, Habitat, ReviewStatus, TestApplication } from 'models';
+import { Decision, ReviewStatus, TestApplication } from 'models';
+import useHabitat from 'hooks/utils/useHabitat';
 import style from './Decisions.module.css';
-
-interface IOutletContext {
-  habitat?: Habitat;
-}
 
 interface DecisionsProps {
   application: TestApplication;
 }
 
 const Decisions = ({ application }: DecisionsProps) => {
-  const { habitat }: IOutletContext = useOutletContext();
+  const { habitat } = useHabitat();
 
   const { data: decisions }: { data: Decision[] } = useDecisionsQuery({
     criteria: (c1: RecursiveModelPredicate<Decision>) =>

--- a/src/pages/[habitat]/applicant/applications/ApplicantApplicationsPage.tsx
+++ b/src/pages/[habitat]/applicant/applications/ApplicantApplicationsPage.tsx
@@ -7,7 +7,6 @@ import {
   View,
 } from '@aws-amplify/ui-react';
 import {
-  Habitat,
   ReviewStatus,
   RootForm,
   SubmissionStatus,
@@ -20,10 +19,11 @@ import TableWithPaginator from 'components/TableWithPaginator';
 import Toggle from 'components/Toggle';
 import StatusChip from 'components/StatusChip';
 import { DataStore } from '@aws-amplify/datastore';
-import { Link, useOutletContext } from 'react-router-dom';
+import { Link } from 'react-router-dom';
 import { dateOnly } from 'utils/dates';
 import Chip from 'components/Chip';
 import { stringToHumanReadable } from 'utils/strings';
+import useHabitat from 'hooks/utils/useHabitat';
 import style from './ApplicantApplicationsPage.module.css';
 
 const ReviewStatusChip = ({ status }: { status: keyof typeof ReviewStatus }) =>
@@ -32,10 +32,6 @@ const ReviewStatusChip = ({ status }: { status: keyof typeof ReviewStatus }) =>
   ) : (
     <Chip text="Reviewed" variation="active" />
   );
-
-interface IOutletContext {
-  habitat?: Habitat;
-}
 
 type DataProps =
   | {
@@ -49,7 +45,7 @@ const ApplicantApplicationsPage = () => {
   const [submissionStatusFilter, setSubmissionStatusFilter] = useState<
     keyof typeof SubmissionStatus
   >(SubmissionStatus.INCOMPLETE);
-  const { habitat }: IOutletContext = useOutletContext();
+  const { habitat } = useHabitat();
   const { user } = useAuthenticator((context) => [context.user]);
   const [data, setData] = useState<DataProps>(undefined);
 

--- a/src/pages/[habitat]/applicant/decisions/ApplicantDecisionsPage.tsx
+++ b/src/pages/[habitat]/applicant/decisions/ApplicantDecisionsPage.tsx
@@ -1,5 +1,4 @@
 import { useState, useEffect } from 'react';
-import { useOutletContext } from 'react-router-dom';
 import {
   Flex,
   Heading,
@@ -8,22 +7,16 @@ import {
   useAuthenticator,
 } from '@aws-amplify/ui-react';
 import { DataStore } from '@aws-amplify/datastore';
-
 import DecisionCard from 'components/DecisionCard';
 import {
   Decision,
-  Habitat,
   ReviewStatus,
   RootForm,
   TestApplication,
   TestCycle,
 } from 'models';
-
+import useHabitat from 'hooks/utils/useHabitat';
 import style from './ApplicantDecisionsPage.module.css';
-
-interface IOutletContext {
-  habitat?: Habitat;
-}
 
 type DataProps =
   | {
@@ -34,7 +27,7 @@ type DataProps =
 
 const ApplicantDecisionsPage = () => {
   const { user } = useAuthenticator((context) => [context.user]);
-  const { habitat }: IOutletContext = useOutletContext();
+  const { habitat } = useHabitat();
   const [data, setData] = useState<DataProps>(undefined);
 
   useEffect(() => {


### PR DESCRIPTION
This PR add a Habitat context, with a provider and a custom hook to get the context, fetch habitat info in the HabitatLayout to unify where the habitat info is being fetch, also replace all instances of useOutletContext and habitat props to use the new useHabitat hook.