### PR TITLE
Devquinteros/hab 14 research and resolve resizeobserver bug

### DIFF
--- a/src/components/ExpandableCard/ExpandableCard.tsx
+++ b/src/components/ExpandableCard/ExpandableCard.tsx
@@ -25,14 +25,18 @@ const ExpandableCard = ({ children }: IProperties) => {
   );
 
   useEffect(() => {
-    if (cardRef.current) {
-      const resizeObserver = new ResizeObserver((entries) =>
-        setHeight(entries[0].target.clientHeight)
-      );
-      resizeObserver.observe(cardRef.current);
+    if (!cardRef.current) {
+      return;
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [cardRef.current]);
+
+    const resizeObserver = new ResizeObserver((entries) =>
+      setHeight(entries[0].target.clientHeight)
+    );
+
+    resizeObserver.observe(cardRef.current);
+
+    return () => resizeObserver.disconnect();
+  }, []);
 
   return (
     <View

--- a/src/components/ExpandableCard/ExpandableCard.tsx
+++ b/src/components/ExpandableCard/ExpandableCard.tsx
@@ -30,7 +30,7 @@ const ExpandableCard = ({ children }: IProperties) => {
     }
 
     const resizeObserver = new ResizeObserver((entries) =>
-      setHeight(entries[0].target.clientHeight)
+      requestAnimationFrame(() => setHeight(entries[0].target.clientHeight))
     );
 
     resizeObserver.observe(cardRef.current);

--- a/src/components/ExpandableCardWithGradient/ExpandableCardWithGradient.tsx
+++ b/src/components/ExpandableCardWithGradient/ExpandableCardWithGradient.tsx
@@ -29,7 +29,7 @@ const ExpandableCardWithGradient = ({ children }: IProperties) => {
     }
 
     const resizeObserver = new ResizeObserver((entries) =>
-      setHeight(entries[0].target.clientHeight)
+      requestAnimationFrame(() => setHeight(entries[0].target.clientHeight))
     );
 
     resizeObserver.observe(cardRef.current);

--- a/src/components/ExpandableCardWithGradient/ExpandableCardWithGradient.tsx
+++ b/src/components/ExpandableCardWithGradient/ExpandableCardWithGradient.tsx
@@ -24,14 +24,16 @@ const ExpandableCardWithGradient = ({ children }: IProperties) => {
   );
 
   useEffect(() => {
-    if (cardRef.current) {
-      const resizeObserver = new ResizeObserver((entries) =>
-        setHeight(entries[0].target.clientHeight)
-      );
-      resizeObserver.observe(cardRef.current);
+    if (!cardRef.current) {
+      return;
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [cardRef.current]);
+
+    const resizeObserver = new ResizeObserver((entries) =>
+      setHeight(entries[0].target.clientHeight)
+    );
+
+    resizeObserver.observe(cardRef.current);
+  }, []);
 
   return (
     <Card

--- a/src/components/LexicalEditor/LexicalEditor.jsx
+++ b/src/components/LexicalEditor/LexicalEditor.jsx
@@ -29,7 +29,7 @@ const Placeholder = ({ text, updateHeight }) => {
     if (!textRef.current) return;
     const resizeObserver = new ResizeObserver(() => {
       if (textRef.current) {
-        updateHeight(textRef.current.offsetHeight);
+        requestAnimationFrame(() => updateHeight(textRef.current.offsetHeight));
       }
     });
     resizeObserver.observe(textRef.current);

--- a/src/components/LexicalEditor/plugins/ToolbarPlugin/ToolbarPlugin.jsx
+++ b/src/components/LexicalEditor/plugins/ToolbarPlugin/ToolbarPlugin.jsx
@@ -49,11 +49,6 @@ import style from './ToolbarPlugin.module.css';
 
 const LowPriority = 1;
 
-const buttonProps = {
-  padding: '.5rem',
-  borderStyle: 'none',
-};
-
 const VerticalDivider = () => (
   <Divider orientation="vertical" opacity={1} alignSelf="stretch" />
 );
@@ -282,7 +277,6 @@ const ToolbarPlugin = ({ disableFiles }) => {
           onClick={() => {
             editor.dispatchCommand(FORMAT_TEXT_COMMAND, 'italic');
           }}
-          {...buttonProps}
           className={`${style.toolbarButton} ${isItalic ? style.selected : ''}`}
           aria-label="Format Italics"
           title="Format Italics"
@@ -294,7 +288,6 @@ const ToolbarPlugin = ({ disableFiles }) => {
           onClick={() => {
             editor.dispatchCommand(FORMAT_TEXT_COMMAND, 'underline');
           }}
-          {...buttonProps}
           className={`${style.toolbarButton} ${
             isUnderline ? style.selected : ''
           }`}
@@ -308,7 +301,6 @@ const ToolbarPlugin = ({ disableFiles }) => {
           onClick={() => {
             editor.dispatchCommand(FORMAT_TEXT_COMMAND, 'strikethrough');
           }}
-          {...buttonProps}
           className={`${style.toolbarButton} ${
             isStrikethrough ? style.selected : ''
           }`}
@@ -323,7 +315,6 @@ const ToolbarPlugin = ({ disableFiles }) => {
           onClick={() => {
             editor.dispatchCommand(FORMAT_ELEMENT_COMMAND, 'left');
           }}
-          {...buttonProps}
           aria-label="Left Align"
           title="Left Align"
           className={`${style.toolbarButton}`}
@@ -335,7 +326,6 @@ const ToolbarPlugin = ({ disableFiles }) => {
           onClick={() => {
             editor.dispatchCommand(FORMAT_ELEMENT_COMMAND, 'center');
           }}
-          {...buttonProps}
           aria-label="Center Align"
           title="Center Align"
           className={`${style.toolbarButton}`}
@@ -347,7 +337,6 @@ const ToolbarPlugin = ({ disableFiles }) => {
           onClick={() => {
             editor.dispatchCommand(FORMAT_ELEMENT_COMMAND, 'right');
           }}
-          {...buttonProps}
           aria-label="Right Align"
           title="Right Align"
           className={`${style.toolbarButton}`}
@@ -359,7 +348,6 @@ const ToolbarPlugin = ({ disableFiles }) => {
           onClick={() => {
             editor.dispatchCommand(FORMAT_ELEMENT_COMMAND, 'justify');
           }}
-          {...buttonProps}
           aria-label="Justify Align"
           title="Justify Align"
           className={`${style.toolbarButton}`}
@@ -367,8 +355,8 @@ const ToolbarPlugin = ({ disableFiles }) => {
           <MdFormatAlignJustify />
         </CustomButton>
         <VerticalDivider />
-        <InsertImageButton buttonProps={buttonProps} />
-        {!disableFiles && <InsertFileButton buttonProps={buttonProps} />}
+        <InsertImageButton />
+        {!disableFiles && <InsertFileButton />}
       </Flex>
       <Divider opacity={1} />
     </View>

--- a/src/components/LexicalEditor/plugins/ToolbarPlugin/components/InsertImageButton.jsx
+++ b/src/components/LexicalEditor/plugins/ToolbarPlugin/components/InsertImageButton.jsx
@@ -9,7 +9,7 @@ import CustomButton from 'components/CustomButton/CustomButton';
 import { INSERT_IMAGE_COMMAND } from '../../ImagePlugin';
 import style from '../ToolbarPlugin.module.css';
 
-const InsertImageButton = ({ buttonProps }) => {
+const InsertImageButton = () => {
   const [modalIsOpen, setModalIsOpen] = useState(false);
   const [editor] = useLexicalComposerContext();
   const [type, setType] = useState();
@@ -113,7 +113,6 @@ const InsertImageButton = ({ buttonProps }) => {
       <CustomButton
         variation="text-only"
         onClick={handleOpenClose}
-        {...buttonProps}
         aria-label="Insert Image"
         title="Insert Image"
         className={style.toolbarButton}
@@ -122,10 +121,6 @@ const InsertImageButton = ({ buttonProps }) => {
       </CustomButton>
     </>
   );
-};
-
-InsertImageButton.propTypes = {
-  buttonProps: PropTypes.object,
 };
 
 export default InsertImageButton;


### PR DESCRIPTION
This changes try to fix a bug that triggered a "ResizeObserver loop completed with undelivered notifications." error sometimes. According to [this](https://developer.mozilla.org/en-US/docs/Web/API/ResizeObserver#observation_errors) it happens when the ResizeObserver callback triggered a resize on the element is observing, but I was not able to reproduce it.